### PR TITLE
Restructure into a flattened file cache

### DIFF
--- a/filecache.go
+++ b/filecache.go
@@ -1,13 +1,15 @@
 package filecache
 
 import (
+	"crypto/md5"
+	"fmt"
 	"os"
 	"path"
 	"path/filepath"
 	"sync"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/hashicorp/golang-lru"
+	log "github.com/sirupsen/logrus"
 )
 
 // FileCache is a wrapper for hashicorp/golang-lru
@@ -129,9 +131,17 @@ func (c *FileCache) MaybeDownload(filename string) error {
 
 // GetFileName returns the full storage path and file name for a file, if it were
 // in the cache. This does _not_ check to see if the file is actually _in_ the
-// cache.
+// cache. This builds a cache structure of up to 16 directories, each beginning
+// with the first letter of the MD5 hash of the filename. This is then joined
+// to the base dir and hashed filename to form the cache path for each file.
+//
+// e.g. /base_dir/b/b0804ec967f48520697662a204f5fe72
+//
 func (c *FileCache) GetFileName(filename string) string {
-	dir, file := filepath.Split(filename)
+	hashed := md5.Sum([]byte(filename))
+
+	file := fmt.Sprintf("%x", hashed)
+	dir := fmt.Sprintf("%x", hashed[0])
 	return filepath.Join(c.BaseDir, dir, filepath.FromSlash(path.Clean("/"+file)))
 }
 

--- a/filecache.go
+++ b/filecache.go
@@ -2,6 +2,7 @@ package filecache
 
 import (
 	"crypto/md5"
+	"hash/fnv"
 	"fmt"
 	"os"
 	"path"
@@ -131,17 +132,18 @@ func (c *FileCache) MaybeDownload(filename string) error {
 
 // GetFileName returns the full storage path and file name for a file, if it were
 // in the cache. This does _not_ check to see if the file is actually _in_ the
-// cache. This builds a cache structure of up to 16 directories, each beginning
-// with the first letter of the MD5 hash of the filename. This is then joined
-// to the base dir and hashed filename to form the cache path for each file.
+// cache. This builds a cache structure of up to 256 directories, each beginning
+// with the first 2 letters of the FNV32 hash of the filename. This is then joined
+// to the base dir and MD5 hashed filename to form the cache path for each file.
 //
 // e.g. /base_dir/b/b0804ec967f48520697662a204f5fe72
 //
 func (c *FileCache) GetFileName(filename string) string {
-	hashed := md5.Sum([]byte(filename))
+	hashedFilename := md5.Sum([]byte(filename))
+	hashedDir := fnv.New32().Sum([]byte(filename))
 
-	file := fmt.Sprintf("%x", hashed)
-	dir := fmt.Sprintf("%x", hashed[0])
+	file := fmt.Sprintf("%x", hashedFilename)
+	dir := fmt.Sprintf("%x", hashedDir[:1])
 	return filepath.Join(c.BaseDir, dir, filepath.FromSlash(path.Clean("/"+file)))
 }
 


### PR DESCRIPTION
This PR flattens the cache structure on disk and makes it no longer match the bucket structure. Instead, there will be 256 top level directories, each 2 hex digits from the FNV32 hash of the complete file path. Beneath those will be filenames which are the MD5 hash of the filename. The intent is to leave a lot less garbage on the filesystem to clean up since deeply nested files could leave empty directories behind. Using the two different hash functions should reduce the chance of collisions in the file space to nearly 0. Particularly for the cache size this is likely to be used with.