### PR TITLE
Support different S3 buckets per request

### DIFF
--- a/filecache.go
+++ b/filecache.go
@@ -55,13 +55,10 @@ func NewS3Cache(size int, baseDir string, s3Bucket string, awsRegion string, dow
 		return nil, err
 	}
 
-	downloader, err := newS3Downloader(awsRegion)
-	if err != nil {
-		log.Fatalf("Failed to initialize the S3 downloader: %s", err)
-	}
+	manager := NewS3RegionManagedDownloader(awsRegion)
 
 	fCache.DownloadFunc = func(fname string, localPath string) error {
-		return S3Download(fname, localPath, s3Bucket, downloader, downloadTimeout)
+		return manager.Download(fname, localPath, downloadTimeout)
 	}
 
 	return fCache, nil

--- a/s3.go
+++ b/s3.go
@@ -6,22 +6,76 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3manager"
 	log "github.com/sirupsen/logrus"
 )
 
-func newS3Downloader(awsRegion string) (*s3manager.Downloader, error) {
-	ses, err := session.NewSession(&aws.Config{Region: aws.String(awsRegion)})
+// Manages a cache of s3manager.Downloader s that have been configured
+// for their correct region.
+type S3RegionManagedDownloader struct {
+	sync.RWMutex
+	DefaultRegion   string
+	DownloaderCache map[string]*s3manager.Downloader // Map buckets to regions
+}
+
+// NewS3RegionManagedDownloader returns a configured instance where the default
+// bucket region will be as passed. This means bucket lookups from the cache
+// will prefer that region when hinting to S3 which region they believe a bucket
+// lives in.
+func NewS3RegionManagedDownloader(defaultRegion string) *S3RegionManagedDownloader {
+	return &S3RegionManagedDownloader{
+		DefaultRegion:   defaultRegion,
+		DownloaderCache: make(map[string]*s3manager.Downloader),
+	}
+}
+
+// GetDownloader looks up a bucket in the cache and returns a configured
+// s3manager.Downloader for it or provisions a new one and returns that.
+// NOTE! This is never flushed and so should not be used with an unlimited
+// number of buckets! The first few requests will incur an additional
+// penalty of roundtrips to Amazon to look up the region fo the requested
+// S3 bucket.
+func (m *S3RegionManagedDownloader) GetDownloader(ctx context.Context, bucket string) (*s3manager.Downloader, error) {
+
+	m.RLock()
+	// Look it up in the cache first
+	if dLoader, ok := m.DownloaderCache[bucket]; ok {
+		m.RUnlock()
+		return dLoader, nil
+	}
+	m.RUnlock()
+
+	// We need an arbitrary, region-less session
+	sess := session.Must(session.NewSession())
+
+	region, err := s3manager.GetBucketRegion(ctx, sess, bucket, m.DefaultRegion)
 	if err != nil {
-		return nil, fmt.Errorf("Could not create S3 session for region '%s': %s", awsRegion, err)
+		if aerr, ok := err.(awserr.Error); ok && aerr.Code() == "NotFound" {
+			return nil, fmt.Errorf("Region for %s not found", bucket)
+		}
+		return nil, err
+	}
+	log.Debugf("Bucket '%s' is in region: %s", bucket, region)
+
+	sess, err = session.NewSession(&aws.Config{Region: aws.String(region)})
+	if err != nil {
+		return nil, fmt.Errorf("Could not create S3 session for region '%s': %s", region, err)
 	}
 
-	return s3manager.NewDownloader(ses), nil
+	// Configure and then cache the downloader
+	dLoader := s3manager.NewDownloader(sess)
+	m.Lock()
+	m.DownloaderCache[bucket] = dLoader
+	m.Unlock()
+
+	return dLoader, nil
 }
 
 func hasDirectoryComponent(localPath string) bool {
@@ -32,10 +86,19 @@ func hasDirectoryComponent(localPath string) bool {
 	return len(parts) > 1
 }
 
-// S3Download will fetch a file from the specified bucket into a localPath. It
+// Download will fetch a file from the specified bucket into a localPath. It
 // will create sub-directories as needed inside that path in order to store the
 // complete path name of the file.
-func S3Download(fname string, localPath string, bucket string, downloader *s3manager.Downloader, downloadTimeout time.Duration) error {
+func (m *S3RegionManagedDownloader) Download(fname string, localPath string, downloadTimeout time.Duration) error {
+
+	// The S3 bucket is the first part of the path, everything else is filename
+	parts := strings.Split(fname, "/")
+	if len(parts) < 2 {
+		return fmt.Errorf("Not enough path to fetch a file! Expected <bucket>/<filename>")
+	}
+	bucket := parts[0]
+	fname = strings.Join(parts[1:], "/")
+
 	if hasDirectoryComponent(localPath) {
 		log.Debugf("MkdirAll() on %s", filepath.Dir(localPath))
 		err := os.MkdirAll(filepath.Dir(localPath), 0755)
@@ -52,6 +115,12 @@ func S3Download(fname string, localPath string, bucket string, downloader *s3man
 
 	ctx, cancelFunc := context.WithTimeout(context.Background(), downloadTimeout)
 	defer cancelFunc()
+
+	log.Debugf("Getting downloader for %s", bucket)
+	downloader, err := m.GetDownloader(ctx, bucket)
+	if err != nil {
+		return fmt.Errorf("Unable to get downloader for %s: %s", bucket, err)
+	}
 
 	log.Debugf("Downloading s3://%s/%s", bucket, fname)
 	startTime := time.Now()


### PR DESCRIPTION
Each request for a file contains the bucket name in the first section of the path. We then look up the region using the S3 API and cache the resulting downloader in a map. Subsequent requests for the bucket return the cached downloader.

This design does **NOT** actively manage the cache map. This is perfect for sites which will be requesting from a limited number of buckets. It is super bad if you somehow plan to query tons of buckets. However, since the current limit of S3 buckets per account is 100 on AWS, this seems quite reasonable for 99.99% of installations. My guess is that you'll use 3-4 maximum in most cases.

**Note**: This breaks the public API for the `S3Downloader`, but not for the main `FileCache`. I believe that's OK. Currently usage of the package looks like it's not going to break anyone.