### PR TITLE
Add ability to have default file extension

### DIFF
--- a/filecache.go
+++ b/filecache.go
@@ -18,12 +18,13 @@ import (
 
 // FileCache is a wrapper for hashicorp/golang-lru
 type FileCache struct {
-	BaseDir      string
-	Cache        *lru.Cache
-	Waiting      map[string]chan struct{}
-	WaitLock     sync.Mutex
-	DownloadFunc func(fname string, localPath string) error
-	OnEvict      func(key interface{}, value interface{})
+	BaseDir          string
+	Cache            *lru.Cache
+	Waiting          map[string]chan struct{}
+	WaitLock         sync.Mutex
+	DownloadFunc     func(fname string, localPath string) error
+	OnEvict          func(key interface{}, value interface{})
+	DefaultExtension string // Will be appended to cached files in the local dir
 }
 
 // New returns a properly configured cache. Bubbles up errors from the Hashicrorp
@@ -187,10 +188,12 @@ func (c *FileCache) GetFileName(filename string) string {
 	hashedFilename := md5.Sum([]byte(filename))
 	hashedDir := fnv.New32().Sum([]byte(filename))
 
-	var extension string
+	// If we don't find an original file extension, we'll default to this one
+	extension := c.DefaultExtension
+
 	// Look in the last 5 characters for a . and extension
 	lastDot := strings.LastIndexByte(filename, '.')
-	if lastDot > len(filename)-5 {
+	if lastDot > len(filename)-6 {
 		extension = filename[lastDot:len(filename)]
 	}
 

--- a/filecache_test.go
+++ b/filecache_test.go
@@ -245,4 +245,24 @@ var _ = Describe("Filecache", func() {
 			Expect(didRun).To(BeTrue())
 		})
 	})
+
+	Describe("GetFileName()", func() {
+		BeforeEach(func() {
+			cache, _ = NewS3Cache(10, ".", "gondor-north-1", 1*time.Millisecond)
+		})
+
+		It("appends a default extension when there is not one on the original file", func() {
+			cache.DefaultExtension = ".foo"
+			fname := cache.GetFileName("missing-an-extension")
+
+			Expect(fname).To(HaveSuffix(".foo"))
+		})
+
+		It("doesn't append the default extension when the original has one", func() {
+			cache.DefaultExtension = ".foo"
+			fname := cache.GetFileName("has-an-extension.asdf")
+
+			Expect(fname).To(HaveSuffix(".asdf"))
+		})
+	})
 })


### PR DESCRIPTION
With @mihaitodor . This allows us to have a default file extension for files in the local cache directory. Useful for software you might run locally that needs to know what the file type is but is too stupid to identify it.