### PR TITLE
Add Dropbox downloader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.swp
 *.swo
 foo.pdf
+junk

--- a/dropbox.go
+++ b/dropbox.go
@@ -1,0 +1,66 @@
+package filecache
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/dropbox/dropbox-sdk-go-unofficial/dropbox"
+	"github.com/dropbox/dropbox-sdk-go-unofficial/dropbox/files"
+	log "github.com/sirupsen/logrus"
+	"golang.org/x/oauth2"
+)
+
+// DropboxDownload will fetch a file from the specified Dropbox path into a localFile. It
+// will create sub-directories as needed inside that path in order to store the
+// complete path name of the file.
+func DropboxDownload(downloadRecord *DownloadRecord, localFile *os.File, downloadTimeout time.Duration) error {
+	accessToken := downloadRecord.Args[strings.ToLower("DropboxAccessToken")]
+	if accessToken == "" {
+		return errors.New("missing DropboxAccessToken header")
+	}
+
+	// The actual path of the file should be after the "dropbox" prefix
+	if !strings.HasPrefix(downloadRecord.Path, "dropbox/") {
+		return errors.New("missing dropbox prefix in file path")
+	}
+	// Leave the leading '/' in place, because Dropbox expects absolute paths
+	filePath := strings.TrimLeft(downloadRecord.Path, "dropbox")
+
+	// Ripped off from here https://github.com/dropbox/dropbox-sdk-go-unofficial/blob/7afa861bfde5a348d765522b303b6fbd9d250155/dropbox/sdk.go#L153-L157
+	// because we have to set the `Client` field manually in `dropbox.Config` if we want to configure
+	// a custom timeout :(
+	conf := &oauth2.Config{Endpoint: dropbox.OAuthEndpoint(".dropboxapi.com")}
+	tok := &oauth2.Token{AccessToken: accessToken}
+	client := conf.Client(context.Background(), tok)
+	client.Timeout = downloadTimeout
+
+	dbx := files.New(
+		dropbox.Config{
+			Token:  accessToken,
+			Client: client,
+			// Enable Dropbox logging if needed
+			// LogLevel: dropbox.LogInfo,
+		},
+	)
+
+	startTime := time.Now()
+	_, content, err := dbx.Download(files.NewDownloadArg(filePath))
+	if err != nil {
+		return fmt.Errorf("could not download file: %s", err)
+	}
+	defer content.Close()
+
+	numBytes, err := io.Copy(localFile, content)
+	if err != nil {
+		return fmt.Errorf("failed to write local file: %s", err)
+	}
+
+	log.Debugf("Took %s to download %d bytes from Dropbox for %s", time.Since(startTime), numBytes, downloadRecord.Path)
+
+	return nil
+}

--- a/filecache.go
+++ b/filecache.go
@@ -2,6 +2,7 @@ package filecache
 
 import (
 	"crypto/md5"
+	"errors"
 	"fmt"
 	"hash/fnv"
 	"os"
@@ -16,54 +17,171 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+const (
+	DownloadMangerS3 = iota
+	DownloadMangerDropbox
+)
+
+var (
+	errInvalidURLPath = errors.New("invalid URL path")
+)
+
+type DownloadManager int
+
+// DownloadRecord contains information about a file which will be downloaded
+type DownloadRecord struct {
+	Manager DownloadManager
+	Path    string
+	Args    map[string]string
+}
+
+type RecordDownloaderFunc = func(downloadRecord *DownloadRecord, localFile *os.File) error
+
 // FileCache is a wrapper for hashicorp/golang-lru
 type FileCache struct {
 	BaseDir          string
 	Cache            *lru.Cache
 	Waiting          map[string]chan struct{}
 	WaitLock         sync.Mutex
-	DownloadFunc     func(fname string, localPath string) error
+	DownloadFunc     func(downloadRecord *DownloadRecord, localPath string) error
 	OnEvict          func(key interface{}, value interface{})
-	DefaultExtension string // Will be appended to cached files in the local dir
+	DefaultExtension string
+	DownloadTimeout  time.Duration
+	downloaders      map[DownloadManager]RecordDownloaderFunc
+}
+
+type option func(*FileCache) error
+
+func setSize(size int) option {
+	return func(c *FileCache) error {
+		cache, err := lru.NewWithEvict(size, c.onEvictDelete)
+		if err != nil {
+			return fmt.Errorf("invalid size: %s", err)
+		}
+
+		c.Cache = cache
+
+		return nil
+	}
+}
+
+func setBaseDir(baseDir string) option {
+	return func(c *FileCache) error {
+		if baseDir == "" {
+			return errors.New("empty baseDir")
+		}
+
+		c.BaseDir = baseDir
+
+		return nil
+	}
+}
+
+// DownloadTimeout sets the file download timeout
+func DownloadTimeout(timeout time.Duration) option {
+	return func(c *FileCache) error {
+		c.DownloadTimeout = timeout
+
+		return nil
+	}
+}
+
+// DefaultExtension sets the default extension which will be appended to
+// cached files in the local directory
+func DefaultExtension(ext string) option {
+	return func(c *FileCache) error {
+		c.DefaultExtension = ext
+
+		return nil
+	}
+}
+
+// S3Downloader allows the DownloadFunc to pull files from S3 buckets.
+// Bucket names are passed at the first part of the path in files requested
+// from the cache. Bubbles up errors from the Hashicrorp LRU library
+// when something goes wrong there.
+func S3Downloader(awsRegion string) option {
+	return func(c *FileCache) error {
+		c.downloaders[DownloadMangerS3] = func(downloadRecord *DownloadRecord, localFile *os.File) error {
+			return NewS3RegionManagedDownloader(awsRegion).Download(
+				downloadRecord, localFile, c.DownloadTimeout,
+			)
+		}
+
+		return nil
+	}
+}
+
+// DropboxDownloader allows the DownloadFunc to pull files from Dropbox
+// accounts. Bubbles up errors from the Hashicrorp LRU library when
+// something goes wrong there.
+func DropboxDownloader() option {
+	return func(c *FileCache) error {
+		c.downloaders[DownloadMangerDropbox] = func(downloadRecord *DownloadRecord, localFile *os.File) error {
+			return DropboxDownload(downloadRecord, localFile, c.DownloadTimeout)
+		}
+
+		return nil
+	}
+}
+
+func hasDirectoryComponent(localPath string) bool {
+	parts := strings.Split(localPath, "/")
+	if len(parts) == 2 && parts[0][0] == '.' {
+		return false
+	}
+	return len(parts) > 1
+}
+
+// download is a generic wrapper which performs common actions before delegating to the
+// specific downloader implementations
+func (c *FileCache) download(downloadRecord *DownloadRecord, localPath string) error {
+	if hasDirectoryComponent(localPath) {
+		// Make sure the path to the local file exists
+		log.Debugf("MkdirAll() on %s", filepath.Dir(localPath))
+		err := os.MkdirAll(filepath.Dir(localPath), 0755)
+		if err != nil {
+			return fmt.Errorf("could not create local directory: %s", err)
+		}
+	}
+
+	localFile, err := os.Create(localPath)
+	if err != nil {
+		return fmt.Errorf("could not create local file: %s", err)
+	}
+	defer localFile.Close()
+
+	if downloader, ok := c.downloaders[downloadRecord.Manager]; ok {
+		return downloader(downloadRecord, localFile)
+	}
+
+	return fmt.Errorf("no dowloader found for %q", downloadRecord.Path)
 }
 
 // New returns a properly configured cache. Bubbles up errors from the Hashicrorp
 // LRU library when something goes wrong there. The configured cache will have a
 // noop DownloadFunc, which should be replaced if you want to actually get files
 // from somewhere. Or, look at NewS3Cache() which is backed by Amazon S3.
-func New(size int, baseDir string) (*FileCache, error) {
+func New(size int, baseDir string, opts ...option) (*FileCache, error) {
 	fCache := &FileCache{
-		BaseDir:      baseDir,
-		Waiting:      make(map[string]chan struct{}),
-		DownloadFunc: func(fname string, localPath string) error { return nil },
+		Waiting:     make(map[string]chan struct{}),
+		downloaders: make(map[DownloadManager]RecordDownloaderFunc),
 	}
+	fCache.DownloadFunc = fCache.download
 
-	cache, err := lru.NewWithEvict(size, fCache.onEvictDelete)
-	if err != nil {
+	if err := setSize(size)(fCache); err != nil {
 		return nil, err
 	}
 
-	fCache.Cache = cache
-
-	return fCache, nil
-}
-
-// NewS3Cache returns a cache where the DownloadFunc will pull files from
-// S3 buckets. Bucket names are passed at the first part of the path in
-// files requested from the cache. Bubbles up errors from the Hashicrorp LRU
-// library when something goes wrong there.
-func NewS3Cache(size int, baseDir string, awsRegion string,
-	downloadTimeout time.Duration) (*FileCache, error) {
-
-	fCache, err := New(size, baseDir)
-	if err != nil {
+	if err := setBaseDir(baseDir)(fCache); err != nil {
 		return nil, err
 	}
 
-	manager := NewS3RegionManagedDownloader(awsRegion)
-
-	fCache.DownloadFunc = func(fname string, localPath string) error {
-		return manager.Download(fname, localPath, downloadTimeout)
+	for _, opt := range opts {
+		err := opt(fCache)
+		if err != nil {
+			return nil, fmt.Errorf("invalid option: %s", err)
+		}
 	}
 
 	return fCache, nil
@@ -72,37 +190,37 @@ func NewS3Cache(size int, baseDir string, awsRegion string,
 // FetchNewerThan will look in the cache for a file, make sure it's newer than
 // timestamp, and if so return true. Otherwise it will possibly download the file
 // and only return false if it's unable to do so.
-func (c *FileCache) FetchNewerThan(filename string, timestamp time.Time) bool {
-	if !c.Contains(filename) {
-		return c.Fetch(filename)
+func (c *FileCache) FetchNewerThan(downloadRecord *DownloadRecord, timestamp time.Time) bool {
+	if !c.Contains(downloadRecord) {
+		return c.Fetch(downloadRecord)
 	}
 
-	storagePath := c.GetFileName(filename)
+	storagePath := c.GetFileName(downloadRecord)
 	stat, err := times.Stat(storagePath)
 	if err != nil {
-		return c.Fetch(filename)
+		return c.Fetch(downloadRecord)
 	}
 
 	// We use mtime because the file could have been overwritten with new data
 	// Compare the timestamp, and need to check the cache again... could have changed
-	if c.Contains(filename) && timestamp.Before(stat.ModTime()) {
+	if c.Contains(downloadRecord) && timestamp.Before(stat.ModTime()) {
 		return true
 	}
 
-	return c.Reload(filename)
+	return c.Reload(downloadRecord)
 }
 
 // Fetch will return true if we have the file, or will go download the file and
 // return true if we can. It will return false only if it's unable to fetch the
 // file from the backing store (S3).
-func (c *FileCache) Fetch(filename string) bool {
-	if c.Contains(filename) {
+func (c *FileCache) Fetch(downloadRecord *DownloadRecord) bool {
+	if c.Contains(downloadRecord) {
 		return true
 	}
 
-	err := c.MaybeDownload(filename)
+	err := c.MaybeDownload(downloadRecord)
 	if err != nil {
-		log.Errorf("Tried to fetch file %s, got '%s'", filename, err)
+		log.Errorf("Tried to fetch file %s, got '%s'", downloadRecord.Path, err)
 		return false
 	}
 
@@ -111,39 +229,39 @@ func (c *FileCache) Fetch(filename string) bool {
 
 // Reload will remove a file from the cache and attempt to reload from the
 // backing store, calling MaybeDownload().
-func (c *FileCache) Reload(filename string) bool {
-	c.Cache.Remove(filename)
+func (c *FileCache) Reload(downloadRecord *DownloadRecord) bool {
+	c.Cache.Remove(downloadRecord.Path)
 
-	err := c.MaybeDownload(filename)
+	err := c.MaybeDownload(downloadRecord)
 	if err != nil {
-		log.Errorf("Tried to fetch file %s, got '%s'", filename, err)
+		log.Errorf("Tried to fetch file %s, got '%s'", downloadRecord.Path, err)
 		return false
 	}
 
 	return true
 }
 
-// Contains looks to see if we have an entry in the cache for this filename.
-func (c *FileCache) Contains(filename string) bool {
-	return c.Cache.Contains(filename)
+// Contains looks to see if we have an entry in the cache for this file.
+func (c *FileCache) Contains(downloadRecord *DownloadRecord) bool {
+	return c.Cache.Contains(downloadRecord.Path)
 }
 
 // MaybeDownload might go out to the backing store (S3) and get the file if the
 // file isn't already being downloaded in another routine. In both cases it will
 // block until the download is completed either by this goroutine or another one.
-func (c *FileCache) MaybeDownload(filename string) error {
+func (c *FileCache) MaybeDownload(downloadRecord *DownloadRecord) error {
 	// See if someone is already downloading
 	c.WaitLock.Lock()
-	if waitChan, ok := c.Waiting[filename]; ok {
+	if waitChan, ok := c.Waiting[downloadRecord.Path]; ok {
 		c.WaitLock.Unlock()
 
-		log.Debugf("Awaiting download of %s", filename)
+		log.Debugf("Awaiting download of %s", downloadRecord.Path)
 		<-waitChan
 		return nil
 	}
 
 	// The file could have arrived while we were getting here
-	if c.Contains(filename) {
+	if c.Contains(downloadRecord) {
 		c.WaitLock.Unlock()
 		return nil
 	}
@@ -151,61 +269,28 @@ func (c *FileCache) MaybeDownload(filename string) error {
 	// Still don't have it, let's fetch it.
 	// This tells other goroutines that we're fetching, and
 	// lets us signal completion.
-	log.Debugf("Making channel for %s", filename)
-	c.Waiting[filename] = make(chan struct{})
+	log.Debugf("Making channel for %s", downloadRecord.Path)
+	c.Waiting[downloadRecord.Path] = make(chan struct{})
 	c.WaitLock.Unlock()
 
 	// Ensure we don't leave the channel open when leaving this function
 	defer func() {
 		c.WaitLock.Lock()
-		log.Debugf("Deleting channel for %s", filename)
-		close(c.Waiting[filename])  // Notify anyone waiting on us
-		delete(c.Waiting, filename) // Remove it from the waiting map
+		log.Debugf("Deleting channel for %s", downloadRecord.Path)
+		close(c.Waiting[downloadRecord.Path])  // Notify anyone waiting on us
+		delete(c.Waiting, downloadRecord.Path) // Remove it from the waiting map
 		c.WaitLock.Unlock()
 	}()
 
-	storagePath := c.GetFileName(filename)
-	err := c.DownloadFunc(filename, storagePath)
+	storagePath := c.GetFileName(downloadRecord)
+	err := c.DownloadFunc(downloadRecord, storagePath)
 	if err != nil {
 		return err
 	}
 
-	c.Cache.Add(filename, storagePath)
+	c.Cache.Add(downloadRecord.Path, storagePath)
 
 	return nil
-}
-
-// GetFileName returns the full storage path and file name for a file, if it were
-// in the cache. This does _not_ check to see if the file is actually _in_ the
-// cache. This builds a cache structure of up to 256 directories, each beginning
-// with the first 2 letters of the FNV32 hash of the filename. This is then joined
-// to the base dir and MD5 hashed filename to form the cache path for each file.
-// It preserves the file extension (if present)
-//
-// e.g. /base_dir/2b/b0804ec967f48520697662a204f5fe72
-//
-func (c *FileCache) GetFileName(filename string) string {
-	hashedFilename := md5.Sum([]byte(filename))
-	fnvHasher := fnv.New32()
-	// The current implementation of fnv.New32().Write never returns a non-nil error
-	_, err := fnvHasher.Write([]byte(filename))
-	if err != nil {
-		log.Errorf("Failed to compute the fnv hash: %s", err)
-	}
-	hashedDir := fnvHasher.Sum(nil)
-
-	// If we don't find an original file extension, we'll default to this one
-	extension := c.DefaultExtension
-
-	// Look in the last 5 characters for a . and extension
-	lastDot := strings.LastIndexByte(filename, '.')
-	if lastDot > len(filename)-6 {
-		extension = filename[lastDot:]
-	}
-
-	file := fmt.Sprintf("%x%s", hashedFilename, extension)
-	dir := fmt.Sprintf("%x", hashedDir[:1])
-	return filepath.Join(c.BaseDir, dir, filepath.FromSlash(path.Clean("/"+file)))
 }
 
 // onEvictDelete is a callback that is triggered when the LRU cache expires an
@@ -241,4 +326,72 @@ func (c *FileCache) PurgeAsync(doneChan chan struct{}) {
 			close(doneChan)
 		}
 	}()
+}
+
+// GetFileName returns the full storage path and file name for a file, if it were
+// in the cache. This does _not_ check to see if the file is actually _in_ the
+// cache. This builds a cache structure of up to 256 directories, each beginning
+// with the first 2 letters of the FNV32 hash of the filename. This is then joined
+// to the base dir and MD5 hashed filename to form the cache path for each file.
+// It preserves the file extension (if present)
+//
+// e.g. /base_dir/2b/b0804ec967f48520697662a204f5fe72
+//
+func (c *FileCache) GetFileName(downloadRecord *DownloadRecord) string {
+	hashedFilename := md5.Sum([]byte(downloadRecord.Path))
+	fnvHasher := fnv.New32()
+	// The current implementation of fnv.New32().Write never returns a non-nil error
+	_, err := fnvHasher.Write([]byte(downloadRecord.Path))
+	if err != nil {
+		log.Errorf("Failed to compute the fnv hash: %s", err)
+	}
+	hashedDir := fnvHasher.Sum(nil)
+
+	// If we don't find an original file extension, we'll default to this one
+	extension := c.DefaultExtension
+
+	// Look in the last 5 characters for a . and extension
+	lastDot := strings.LastIndexByte(downloadRecord.Path, '.')
+	if lastDot > len(downloadRecord.Path)-6 {
+		extension = downloadRecord.Path[lastDot:]
+	}
+
+	file := fmt.Sprintf("%x%s", hashedFilename, extension)
+	dir := fmt.Sprintf("%x", hashedDir[:1])
+	return filepath.Join(c.BaseDir, dir, filepath.FromSlash(path.Clean("/"+file)))
+}
+
+// bucketToDownloadManager matches the given bucket to a suitable download manager
+// TODO: Implement this in a more robust / generic way
+func bucketToDownloadManager(bucket string) DownloadManager {
+	switch bucket {
+	case "dropbox":
+		return DownloadMangerDropbox
+	default:
+		return DownloadMangerS3
+	}
+}
+
+// NewDownloadRecord converts the incoming URL path into a download record containing a cached
+// filename (this is the filename on the backing store, not the cached filename locally)
+// together with the args needed for authentication
+func NewDownloadRecord(url string, args map[string]string) (*DownloadRecord, error) {
+	pathParts := strings.Split(strings.TrimPrefix(url, "/documents/"), "/")
+
+	// We need at least a bucket and filename
+	if len(pathParts) < 2 {
+		return nil, errInvalidURLPath
+	}
+
+	path := strings.Join(pathParts, "/")
+
+	if path == "" || path == "/" {
+		return nil, errInvalidURLPath
+	}
+
+	return &DownloadRecord{
+		Manager: bucketToDownloadManager(pathParts[0]),
+		Path:    path,
+		Args:    args,
+	}, nil
 }

--- a/filecache_suite_test.go
+++ b/filecache_suite_test.go
@@ -1,4 +1,4 @@
-package filecache_test
+package filecache
 
 import (
 	. "github.com/onsi/ginkgo"


### PR DESCRIPTION
We need to have a way to fetch and cache files from Dropbox in Lazyraster and this is my attempt to do so. Unfortunately, because each file needs a Dropbox access token, I had to modify the whole API and replace the `filename` string with a struct that contains both the file path and the access token.

Not sure if there is a cleaner way to do this, but this works for now.