### PR TITLE
Avoid file cache collision on the same filename

### DIFF
--- a/dropbox.go
+++ b/dropbox.go
@@ -15,13 +15,17 @@ import (
 	"golang.org/x/oauth2"
 )
 
+const (
+	dropboxAccessToken = "DropboxAccessToken"
+)
+
 // DropboxDownload will fetch a file from the specified Dropbox path into a localFile. It
 // will create sub-directories as needed inside that path in order to store the
 // complete path name of the file.
 func DropboxDownload(downloadRecord *DownloadRecord, localFile *os.File, downloadTimeout time.Duration) error {
-	accessToken := downloadRecord.Args[strings.ToLower("DropboxAccessToken")]
+	accessToken := downloadRecord.Args[strings.ToLower(dropboxAccessToken)]
 	if accessToken == "" {
-		return errors.New("missing DropboxAccessToken header")
+		return fmt.Errorf("missing %q header", dropboxAccessToken)
 	}
 
 	// The actual path of the file should be after the "dropbox" prefix

--- a/filecache.go
+++ b/filecache.go
@@ -356,9 +356,34 @@ func (c *FileCache) GetFileName(downloadRecord *DownloadRecord) string {
 		extension = downloadRecord.Path[lastDot:]
 	}
 
-	file := fmt.Sprintf("%x%s", hashedFilename, extension)
+	var file string
+	if len(downloadRecord.Args) != 0 {
+		// in order to avoid file cache collision on the same filename, if we
+		// have existing HTTP headers into the downloadRecord.Args append their
+		// hashed value between the hashedFilename and extension with _ prefix
+		hashedArgs := getHashedArguments(downloadRecord)
+		file = fmt.Sprintf("%x_%x%s", hashedFilename, hashedArgs, extension)
+	} else {
+		file = fmt.Sprintf("%x%s", hashedFilename, extension)
+	}
+
 	dir := fmt.Sprintf("%x", hashedDir[:1])
 	return filepath.Join(c.BaseDir, dir, filepath.FromSlash(path.Clean("/"+file)))
+}
+
+// getHashedArguments computes the MD5 sum of all the arguments existing in a
+// downloadRecord and return the hashed value as a string
+func getHashedArguments(downloadRecord *DownloadRecord) string {
+	var builder strings.Builder
+	for key, _ := range downloadRecord.Args {
+		_, err := builder.WriteString(downloadRecord.Args[key])
+		if err != nil {
+			continue
+		}
+	}
+
+	hashedArgs := md5.Sum([]byte(builder.String()))
+	return string(hashedArgs[:])
 }
 
 // bucketToDownloadManager matches the given bucket to a suitable download manager


### PR DESCRIPTION
Using the `DropboxDownloader` it's possible to have a collision when
looking for a file into the cache when filename has the same value.
To avoid it, we changed the implementation of `GetFilename()` when a
downloadRecord has existing arguments and use their values to compute a
hashedArgs used to build the filepath in the cache.

TODO:
- [x] Add Tests