### PR TITLE
Normalise arg name casing

### DIFF
--- a/dropbox.go
+++ b/dropbox.go
@@ -15,15 +15,15 @@ import (
 	"golang.org/x/oauth2"
 )
 
-const (
-	dropboxAccessToken = "DropboxAccessToken"
+var (
+	dropboxAccessToken = strings.ToLower("DropboxAccessToken")
 )
 
 // DropboxDownload will fetch a file from the specified Dropbox path into a localFile. It
 // will create sub-directories as needed inside that path in order to store the
 // complete path name of the file.
 func DropboxDownload(downloadRecord *DownloadRecord, localFile *os.File, downloadTimeout time.Duration) error {
-	accessToken := downloadRecord.Args[strings.ToLower(dropboxAccessToken)]
+	accessToken := downloadRecord.Args[dropboxAccessToken]
 	if accessToken == "" {
 		return fmt.Errorf("missing %q header", dropboxAccessToken)
 	}

--- a/filecache.go
+++ b/filecache.go
@@ -417,9 +417,15 @@ func NewDownloadRecord(url string, args map[string]string) (*DownloadRecord, err
 		return nil, errInvalidURLPath
 	}
 
+	// Make sure all arg names are lower case
+	normalisedArgs := make(map[string]string, len(args))
+	for arg, value := range args {
+		normalisedArgs[strings.ToLower(arg)] = value
+	}
+
 	return &DownloadRecord{
 		Manager: bucketToDownloadManager(pathParts[0]),
 		Path:    path,
-		Args:    args,
+		Args:    normalisedArgs,
 	}, nil
 }

--- a/filecache_test.go
+++ b/filecache_test.go
@@ -3,6 +3,7 @@ package filecache
 import (
 	"crypto/md5"
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"net/url"
 	"os"
@@ -349,12 +350,24 @@ var _ = Describe("Filecache", func() {
 		It("should hash only the HashableArgs", func() {
 			args := map[string]string{
 				"DropboxAccessToken": "Frodo",
-				"S3AccessToken":      "Bilbon",
+				"FoobarAccessToken":  "Bilbo",
 			}
-			mockRecord := &DownloadRecord{Manager: DownloadMangerDropbox, Path: "", Args: args}
-			got := mockRecord.GetHashedArguments()
+			mockRecord, _ := NewDownloadRecord("/documents/dropbox/foo-file.pdf", args)
+			got := fmt.Sprintf("%x", mockRecord.GetHashedArguments())
 			sum := md5.Sum([]byte(args["DropboxAccessToken"]))
-			want := string(sum[:])
+			want := fmt.Sprintf("%x", sum[:])
+
+			Expect(got).To(Equal(want))
+		})
+
+		It("should ignore header name casing", func() {
+			args := map[string]string{
+				"Dropboxaccesstoken": "Frodo",
+			}
+			mockRecord, _ := NewDownloadRecord("/documents/dropbox/foo-file.pdf", args)
+			got := fmt.Sprintf("%x", mockRecord.GetHashedArguments())
+			sum := md5.Sum([]byte(args["Dropboxaccesstoken"]))
+			want := fmt.Sprintf("%x", sum[:])
 
 			Expect(got).To(Equal(want))
 		})


### PR DESCRIPTION
The issue from yesterday was a typo in the arg name in the test :(

TODO:
- [x] Get rid of the `strings.ToLower` call [here](https://github.com/Nitro/lazyraster/blob/30a3d11be11af1b075d4ed23164e23374eb529d3/http.go#L212).