### PR TITLE
Use hashed args in cache key

### DIFF
--- a/dropbox.go
+++ b/dropbox.go
@@ -22,19 +22,19 @@ var (
 // DropboxDownload will fetch a file from the specified Dropbox path into a localFile. It
 // will create sub-directories as needed inside that path in order to store the
 // complete path name of the file.
-func DropboxDownload(downloadRecord *DownloadRecord, localFile *os.File, downloadTimeout time.Duration) error {
-	accessToken := downloadRecord.Args[dropboxAccessToken]
+func DropboxDownload(dr *DownloadRecord, localFile *os.File, downloadTimeout time.Duration) error {
+	accessToken := dr.Args[dropboxAccessToken]
 	if accessToken == "" {
 		return fmt.Errorf("missing %q header", dropboxAccessToken)
 	}
 
 	// The actual path of the file should be after the "dropbox" prefix
-	if !strings.HasPrefix(downloadRecord.Path, "dropbox/") {
+	if !strings.HasPrefix(dr.Path, "dropbox/") {
 		return errors.New("missing dropbox prefix in file path")
 	}
 
 	// In the case of Dropbox files, the path will contain the file ID
-	fileID := "id:" + strings.TrimLeft(downloadRecord.Path, "dropbox/")
+	fileID := "id:" + strings.TrimLeft(dr.Path, "dropbox/")
 
 	// Ripped off from here https://github.com/dropbox/dropbox-sdk-go-unofficial/blob/7afa861bfde5a348d765522b303b6fbd9d250155/dropbox/sdk.go#L153-L157
 	// because we have to set the `Client` field manually in `dropbox.Config` if we want to configure
@@ -65,7 +65,7 @@ func DropboxDownload(downloadRecord *DownloadRecord, localFile *os.File, downloa
 		return fmt.Errorf("failed to write local file: %s", err)
 	}
 
-	log.Debugf("Took %s to download %d bytes from Dropbox for %s", time.Since(startTime), numBytes, downloadRecord.Path)
+	log.Debugf("Took %s to download %d bytes from Dropbox for %s", time.Since(startTime), numBytes, dr.Path)
 
 	return nil
 }

--- a/filecache_test.go
+++ b/filecache_test.go
@@ -179,6 +179,29 @@ var _ = Describe("Filecache", func() {
 			Expect(cache.Fetch(&DownloadRecord{Path: "aragorn"})).To(BeTrue())
 			Expect(didDownload).To(BeTrue())
 		})
+
+		It("downloads a new file for records with the same path but different args", func() {
+			url, _ := url.Parse("/documents/test-bucket/foo.bar")
+			args := map[string]string{
+				dropboxAccessToken: "KnockKnock",
+			}
+
+			fooRec, _ := NewDownloadRecord(url.Path, args)
+			Expect(cache.Fetch(fooRec)).To(BeTrue())
+			Expect(didDownload).To(BeTrue())
+
+			// It should be in the cache now
+			didDownload = false
+			Expect(cache.Fetch(fooRec)).To(BeTrue())
+			Expect(didDownload).To(BeFalse())
+
+			// Using different args should create a new cache entry
+			didDownload = false
+			args[dropboxAccessToken] = "ComeIn"
+			fooRec, _ = NewDownloadRecord(url.Path, args)
+			Expect(cache.Fetch(fooRec)).To(BeTrue())
+			Expect(didDownload).To(BeTrue())
+		})
 	})
 
 	Describe("FetchNewerThan()", func() {

--- a/filecache_test.go
+++ b/filecache_test.go
@@ -29,7 +29,7 @@ var _ = Describe("Filecache", func() {
 		cacheFile           string
 	)
 
-	mockDownloader := func(downloadRecord *DownloadRecord, localPath string) error {
+	mockDownloader := func(dr *DownloadRecord, localPath string) error {
 		if downloadShouldError {
 			return errors.New("Oh no! Tragedy!")
 		}

--- a/s3.go
+++ b/s3.go
@@ -81,8 +81,8 @@ func (m *S3RegionManagedDownloader) GetDownloader(ctx context.Context, bucket st
 // Download will fetch a file from the specified bucket into a localFile. It
 // will create sub-directories as needed inside that path in order to store the
 // complete path name of the file.
-func (m *S3RegionManagedDownloader) Download(downloadRecord *DownloadRecord, localFile *os.File, downloadTimeout time.Duration) error {
-	fname := downloadRecord.Path
+func (m *S3RegionManagedDownloader) Download(dr *DownloadRecord, localFile *os.File, downloadTimeout time.Duration) error {
+	fname := dr.Path
 
 	// The S3 bucket is the first part of the path, everything else is filename
 	parts := strings.Split(fname, "/")


### PR DESCRIPTION
We want to download the same Dropbox file again for different access tokens. Hence, we append the hashed args in the LRU cache key.