### PR TITLE
ENG-11342: Use standard HTTP Authorization header

### DIFF
--- a/filecache.go
+++ b/filecache.go
@@ -24,7 +24,8 @@ const (
 
 var (
 	errInvalidURLPath = errors.New("invalid URL path")
-	HashableArgs      = map[string]struct{}{dropboxAccessToken: {}}
+	authTokenArg      = strings.ToLower("authorization")
+	HashableArgs      = map[string]struct{}{authTokenArg: {}}
 )
 
 type DownloadManager int

--- a/filecache_test.go
+++ b/filecache_test.go
@@ -183,7 +183,7 @@ var _ = Describe("Filecache", func() {
 
 		It("downloads a new file for records with the same path but different args", func() {
 			args := map[string]string{
-				dropboxAccessToken: "KnockKnock",
+				authTokenArg: "KnockKnock",
 			}
 
 			fooRec, _ := NewDownloadRecord(s3FilePath, args)
@@ -197,7 +197,7 @@ var _ = Describe("Filecache", func() {
 
 			// Using different args should create a new cache entry
 			didDownload = false
-			args[dropboxAccessToken] = "ComeIn"
+			args[authTokenArg] = "ComeIn"
 			fooRec, _ = NewDownloadRecord(dropboxFilePath, args)
 			Expect(cache.Fetch(fooRec)).To(BeTrue())
 			Expect(didDownload).To(BeTrue())
@@ -302,8 +302,8 @@ var _ = Describe("Filecache", func() {
 
 		It("fetches the expected file name for Dropbox downloads", func() {
 			args := map[string]string{
-				dropboxAccessToken: "KnockKnock",
-				"DummyHeader":      "SomeValue",
+				authTokenArg:  "KnockKnock",
+				"DummyHeader": "SomeValue",
 			}
 			dr, _ := NewDownloadRecord(dropboxFilePath, args)
 			fname := cache.GetFileName(dr)
@@ -401,11 +401,11 @@ var _ = Describe("Filecache", func() {
 	Describe("HashedArgs", func() {
 		It("should hash only the HashableArgs", func() {
 			args := map[string]string{
-				"DropboxAccessToken": "Frodo",
-				"FoobarAccessToken":  "Bilbo",
+				"authorization":     "Frodo",
+				"FoobarAccessToken": "Bilbo",
 			}
 			mockRecord, _ := NewDownloadRecord(dropboxFilePath, args)
-			sum := md5.Sum([]byte(args["DropboxAccessToken"]))
+			sum := md5.Sum([]byte(args["authorization"]))
 			want := fmt.Sprintf("%x", sum[:])
 
 			Expect(mockRecord.HashedArgs).To(Equal(want))
@@ -413,10 +413,10 @@ var _ = Describe("Filecache", func() {
 
 		It("should ignore header name casing", func() {
 			args := map[string]string{
-				"Dropboxaccesstoken": "Frodo",
+				"Authorization": "Frodo",
 			}
 			mockRecord, _ := NewDownloadRecord(dropboxFilePath, args)
-			sum := md5.Sum([]byte(args["Dropboxaccesstoken"]))
+			sum := md5.Sum([]byte("Frodo"))
 			want := fmt.Sprintf("%x", sum[:])
 
 			Expect(mockRecord.HashedArgs).To(Equal(want))

--- a/s3_test.go
+++ b/s3_test.go
@@ -59,8 +59,13 @@ var _ = Describe("S3", func() {
 			Expect(dLoader1).To(Equal(dLoader2))
 		})
 
-		It("returns an error when trying to fetch a file which doesn't exist", func() {
+		It("returns an error when trying to fetch a file from a non-existent bucket", func() {
 			err := manager.Download(&DownloadRecord{Path: "non-existent-bucket/foo.pdf"}, localFile, 1*time.Second)
+			Expect(err.Error()).To(ContainSubstring("Unable to get downloader for non-existent-bucket"))
+		})
+
+		It("returns an error when trying to fetch a file which doesn't exist", func() {
+			err := manager.Download(&DownloadRecord{Path: "nitro-junk/non-existent-foo.pdf"}, localFile, 1*time.Second)
 			Expect(err.Error()).To(ContainSubstring("Could not fetch from S3"))
 		})
 


### PR DESCRIPTION
- Rename "DropboxAccessToken" arg to "authorization" as discussed with @epileptic-fish 
- Also fix broken S3 tests (looks like AWS S3 now complains when it can't find a bucket)