### PR TITLE
Change Dropbox api

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -52,33 +52,12 @@
   version = "v1.0.1"
 
 [[projects]]
-  digest = "1:6a16a71a3278c8ddc86848a6a24eb21f5bc692fb6c78c3b2bb42b4ad3d05f2ec"
-  name = "github.com/dropbox/dropbox-sdk-go-unofficial"
-  packages = [
-    "dropbox",
-    "dropbox/async",
-    "dropbox/file_properties",
-    "dropbox/files",
-  ]
-  pruneopts = "UT"
-  revision = "7afa861bfde5a348d765522b303b6fbd9d250155"
-  version = "v4.1.0"
-
-[[projects]]
   digest = "1:b98e7574fc27ec166fb31195ec72c3bd0bffd73926d3612eb4c929bc5236f75b"
   name = "github.com/go-ini/ini"
   packages = ["."]
   pruneopts = "UT"
   revision = "7b294651033cd7d9e7f0d9ffa1b75ed1e198e737"
   version = "v1.38.3"
-
-[[projects]]
-  digest = "1:97df918963298c287643883209a2c3f642e6593379f97ab400c2a2e219ab647d"
-  name = "github.com/golang/protobuf"
-  packages = ["proto"]
-  pruneopts = "UT"
-  revision = "aa810b61a9c79d51363740d207bb46cf8e620ed5"
-  version = "v1.2.0"
 
 [[projects]]
   digest = "1:8ec8d88c248041a6df5f6574b87bc00e7e0b493881dad2e7ef47b11dc69093b5"
@@ -186,28 +165,15 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:1773c29e859f20619b8d70811ff67de2b4dcad02a5fc0bfac16501fa666df147"
+  digest = "1:2394b7d142aba21cd69bdb719c1588dae1aebf115d8f4c033ec0338f30684309"
   name = "golang.org/x/net"
   packages = [
-    "context",
-    "context/ctxhttp",
     "html",
     "html/atom",
     "html/charset",
   ]
   pruneopts = "UT"
   revision = "4dfa2610cdf3b287375bbba5b8f2a14d3b01d8de"
-
-[[projects]]
-  branch = "master"
-  digest = "1:363b547c971a2b07474c598b6e9ebcb238d556d8a27f37b3895ad20cd50e7281"
-  name = "golang.org/x/oauth2"
-  packages = [
-    ".",
-    "internal",
-  ]
-  pruneopts = "UT"
-  revision = "d2e6202438beef2727060aa7cabdd924d92ebfd9"
 
 [[projects]]
   branch = "master"
@@ -247,22 +213,6 @@
   version = "v0.3.0"
 
 [[projects]]
-  digest = "1:6247f76e55a1e1a5c19a81e2d4b4dff6730461eeb5bbb0a16dd4a8ec8637ee93"
-  name = "google.golang.org/appengine"
-  packages = [
-    "internal",
-    "internal/base",
-    "internal/datastore",
-    "internal/log",
-    "internal/remote_api",
-    "internal/urlfetch",
-    "urlfetch",
-  ]
-  pruneopts = "UT"
-  revision = "ae0ab99deb4dc413a2b4bd6c8bdd0eb67f1e4d06"
-  version = "v1.2.0"
-
-[[projects]]
   digest = "1:abeb38ade3f32a92943e5be54f55ed6d6e3b6602761d74b4aab4c9dd45c18abd"
   name = "gopkg.in/fsnotify/fsnotify.v1"
   packages = ["."]
@@ -295,13 +245,10 @@
     "github.com/aws/aws-sdk-go/service/s3",
     "github.com/aws/aws-sdk-go/service/s3/s3manager",
     "github.com/djherbis/times",
-    "github.com/dropbox/dropbox-sdk-go-unofficial/dropbox",
-    "github.com/dropbox/dropbox-sdk-go-unofficial/dropbox/files",
     "github.com/hashicorp/golang-lru",
     "github.com/onsi/ginkgo",
     "github.com/onsi/gomega",
     "github.com/sirupsen/logrus",
-    "golang.org/x/oauth2",
   ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -34,10 +34,6 @@
   version = "1.0.1"
 
 [[constraint]]
-  name = "github.com/dropbox/dropbox-sdk-go-unofficial"
-  version = "4.1.0"
-
-[[constraint]]
   name = "github.com/hashicorp/golang-lru"
   version = "0.5.0"
 
@@ -52,10 +48,6 @@
 [[constraint]]
   name = "github.com/sirupsen/logrus"
   version = "1.1.0"
-
-[[constraint]]
-  branch = "master"
-  name = "golang.org/x/oauth2"
 
 [prune]
   go-tests = true

--- a/dropbox.go
+++ b/dropbox.go
@@ -2,63 +2,41 @@ package filecache
 
 import (
 	"context"
-	"errors"
+	"encoding/base64"
 	"fmt"
 	"io"
-	"os"
+	"net/http"
 	"strings"
 	"time"
 
-	"github.com/dropbox/dropbox-sdk-go-unofficial/dropbox"
-	"github.com/dropbox/dropbox-sdk-go-unofficial/dropbox/files"
 	log "github.com/sirupsen/logrus"
-	"golang.org/x/oauth2"
-)
-
-var (
-	dropboxAccessToken = strings.ToLower("DropboxAccessToken")
 )
 
 // DropboxDownload will download a file from the specified Dropbox location into localFile
-func DropboxDownload(dr *DownloadRecord, localFile *os.File, downloadTimeout time.Duration) error {
-	accessToken := dr.Args[dropboxAccessToken]
-	if accessToken == "" {
-		return fmt.Errorf("missing %q header", dropboxAccessToken)
+func DropboxDownload(dr *DownloadRecord, localFile io.Writer, downloadTimeout time.Duration) error {
+	// In the case of Dropbox files, the path will contain the base64-encoded file URL after dropbox/
+	fileURL, err := base64.StdEncoding.DecodeString(strings.TrimPrefix(dr.Path, "dropbox/"))
+
+	if err != nil {
+		return fmt.Errorf("could not base64 decode file URL: %s", err)
 	}
-
-	// The actual path of the file should be after the "dropbox" prefix
-	if !strings.HasPrefix(dr.Path, "dropbox/") {
-		return errors.New("missing dropbox prefix in file path")
-	}
-
-	// In the case of Dropbox files, the path will contain the file ID
-	fileID := "id:" + strings.TrimLeft(dr.Path, "dropbox/")
-
-	// Ripped off from here https://github.com/dropbox/dropbox-sdk-go-unofficial/blob/7afa861bfde5a348d765522b303b6fbd9d250155/dropbox/sdk.go#L153-L157
-	// because we have to set the `Client` field manually in `dropbox.Config` if we want to configure
-	// a custom timeout :(
-	conf := &oauth2.Config{Endpoint: dropbox.OAuthEndpoint(".dropboxapi.com")}
-	tok := &oauth2.Token{AccessToken: accessToken}
-	client := conf.Client(context.Background(), tok)
-	client.Timeout = downloadTimeout
-
-	dbx := files.New(
-		dropbox.Config{
-			Token:  accessToken,
-			Client: client,
-			// Enable Dropbox logging if needed
-			// LogLevel: dropbox.LogInfo,
-		},
-	)
 
 	startTime := time.Now()
-	_, content, err := dbx.Download(files.NewDownloadArg(fileID))
-	if err != nil {
-		return fmt.Errorf("could not download file: %s", err)
-	}
-	defer content.Close()
+	ctx, cancelFunc := context.WithTimeout(context.Background(), downloadTimeout)
+	defer cancelFunc()
 
-	numBytes, err := io.Copy(localFile, content)
+	req, err := http.NewRequest(http.MethodGet, string(fileURL), nil)
+	if err != nil {
+		return fmt.Errorf("could not create HTTP request for URL %q: %s", fileURL, err)
+	}
+
+	resp, err := http.DefaultClient.Do(req.WithContext(ctx))
+	if err != nil {
+		return fmt.Errorf("failed to download file %q: %s", fileURL, err)
+	}
+	defer resp.Body.Close()
+
+	numBytes, err := io.Copy(localFile, resp.Body)
 	if err != nil {
 		return fmt.Errorf("failed to write local file: %s", err)
 	}

--- a/dropbox.go
+++ b/dropbox.go
@@ -19,9 +19,7 @@ var (
 	dropboxAccessToken = strings.ToLower("DropboxAccessToken")
 )
 
-// DropboxDownload will fetch a file from the specified Dropbox path into a localFile. It
-// will create sub-directories as needed inside that path in order to store the
-// complete path name of the file.
+// DropboxDownload will download a file from the specified Dropbox location into localFile
 func DropboxDownload(dr *DownloadRecord, localFile *os.File, downloadTimeout time.Duration) error {
 	accessToken := dr.Args[dropboxAccessToken]
 	if accessToken == "" {

--- a/dropbox_test.go
+++ b/dropbox_test.go
@@ -31,7 +31,8 @@ func (dw *dummyWriter) Write(p []byte) (n int, err error) {
 var _ = Describe("DropboxDownload", func() {
 	It("downloads a file successfully", func() {
 		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			w.Write([]byte("dummy_content"))
+			_, err := w.Write([]byte("dummy_content"))
+			Expect(err).To(BeNil())
 		}))
 		defer ts.Close()
 		url := fmt.Sprintf(
@@ -84,7 +85,8 @@ var _ = Describe("DropboxDownload", func() {
 
 	It("returns an error when streaming the file to disk fails", func() {
 		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			w.Write([]byte("dummy_content"))
+			_, err := w.Write([]byte("dummy_content"))
+			Expect(err).To(BeNil())
 		}))
 		defer ts.Close()
 		url := fmt.Sprintf(
@@ -103,7 +105,8 @@ var _ = Describe("DropboxDownload", func() {
 
 	It("fails to download when timing out", func() {
 		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			w.Write([]byte("dummy_content"))
+			_, err := w.Write([]byte("dummy_content"))
+			Expect(err).To(BeNil())
 		}))
 		defer ts.Close()
 		url := fmt.Sprintf(

--- a/dropbox_test.go
+++ b/dropbox_test.go
@@ -1,0 +1,122 @@
+package filecache_test
+
+import (
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"time"
+
+	. "github.com/Nitro/filecache"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+type dummyWriter struct {
+	receivedData string
+	writeError   error
+}
+
+func (dw *dummyWriter) Write(p []byte) (n int, err error) {
+	if dw.writeError != nil {
+		return 0, dw.writeError
+	}
+
+	dw.receivedData = string(p)
+	return len(p), nil
+}
+
+var _ = Describe("DropboxDownload", func() {
+	It("downloads a file successfully", func() {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Write([]byte("dummy_content"))
+		}))
+		defer ts.Close()
+		url := fmt.Sprintf(
+			"dropbox/%s",
+			base64.StdEncoding.EncodeToString([]byte(ts.URL)),
+		)
+
+		dr, err := NewDownloadRecord(url, nil)
+		Expect(err).To(BeNil())
+
+		writer := &dummyWriter{}
+		err = DropboxDownload(dr, writer, 100*time.Millisecond)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(writer.receivedData).To(ContainSubstring("dummy_content"))
+	})
+
+	It("fails to decode an invalid base64-encoded Dropbox URL", func() {
+		dr, err := NewDownloadRecord("dropbox/foo.bar", nil)
+		Expect(err).To(BeNil())
+
+		err = DropboxDownload(dr, &dummyWriter{}, 100*time.Millisecond)
+		Expect(err).Should(HaveOccurred())
+	})
+
+	It("fails to create a HTTP request for an invalid URL", func() {
+		url := fmt.Sprintf(
+			"dropbox/%s",
+			base64.StdEncoding.EncodeToString([]byte("ht$tp://invalid_url")),
+		)
+
+		dr, err := NewDownloadRecord(url, nil)
+		Expect(err).To(BeNil())
+
+		err = DropboxDownload(dr, &dummyWriter{}, 100*time.Millisecond)
+		Expect(err).Should(HaveOccurred())
+	})
+
+	It("returns an error when trying to download from an unreachable domain", func() {
+		url := fmt.Sprintf(
+			"dropbox/%s",
+			base64.StdEncoding.EncodeToString([]byte("http://some_dummy_domain.com")),
+		)
+
+		dr, err := NewDownloadRecord(url, nil)
+		Expect(err).To(BeNil())
+
+		err = DropboxDownload(dr, &dummyWriter{}, 100*time.Millisecond)
+		Expect(err).Should(HaveOccurred())
+	})
+
+	It("returns an error when streaming the file to disk fails", func() {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Write([]byte("dummy_content"))
+		}))
+		defer ts.Close()
+		url := fmt.Sprintf(
+			"dropbox/%s",
+			base64.StdEncoding.EncodeToString([]byte(ts.URL)),
+		)
+
+		dr, err := NewDownloadRecord(url, nil)
+		Expect(err).To(BeNil())
+
+		writer := &dummyWriter{writeError: errors.New("dummy_error")}
+		err = DropboxDownload(dr, writer, 100*time.Millisecond)
+		Expect(err).Should(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("dummy_error"))
+	})
+
+	It("fails to download when timing out", func() {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Write([]byte("dummy_content"))
+		}))
+		defer ts.Close()
+		url := fmt.Sprintf(
+			"dropbox/%s",
+			base64.StdEncoding.EncodeToString([]byte(ts.URL)),
+		)
+
+		dr, err := NewDownloadRecord(url, nil)
+		Expect(err).To(BeNil())
+
+		writer := &dummyWriter{}
+		err = DropboxDownload(dr, writer, 0*time.Millisecond)
+		Expect(err).Should(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("context deadline exceeded"))
+	})
+})

--- a/filecache.go
+++ b/filecache.go
@@ -24,7 +24,8 @@ const (
 
 var (
 	errInvalidURLPath = errors.New("invalid URL path")
-	HashableArgs      = map[string]struct{}{dropboxAccessToken: {}}
+	// HashableArgs allows us to support various authentication headers in the future
+	HashableArgs = map[string]struct{}{}
 )
 
 type DownloadManager int

--- a/filecache_test.go
+++ b/filecache_test.go
@@ -28,6 +28,7 @@ var _ = Describe("Filecache", func() {
 		cacheFile           string
 		s3FilePath          = "/documents/test-bucket/foo.bar"
 		dropboxFilePath     = "/documents/dropbox/foo.bar"
+		dropboxAccessToken  = strings.ToLower("DropboxAccessToken")
 	)
 
 	mockDownloader := func(dr *DownloadRecord, localPath string) error {
@@ -43,6 +44,9 @@ var _ = Describe("Filecache", func() {
 		didDownload = true
 		return nil
 	}
+
+	// Set the dummy dropboxAccessToken in the global HashableArgs map
+	HashableArgs[dropboxAccessToken] = struct{}{}
 
 	BeforeEach(func() {
 		cache, err = New(10, ".", DownloadTimeout(1*time.Millisecond), S3Downloader("gondor-north-1"))

--- a/s3.go
+++ b/s3.go
@@ -78,9 +78,7 @@ func (m *S3RegionManagedDownloader) GetDownloader(ctx context.Context, bucket st
 	return dLoader, nil
 }
 
-// Download will fetch a file from the specified bucket into a localFile. It
-// will create sub-directories as needed inside that path in order to store the
-// complete path name of the file.
+// Download will download a file from the specified S3 bucket into localFile
 func (m *S3RegionManagedDownloader) Download(dr *DownloadRecord, localFile *os.File, downloadTimeout time.Duration) error {
 	fname := dr.Path
 

--- a/s3_test.go
+++ b/s3_test.go
@@ -59,9 +59,14 @@ var _ = Describe("S3", func() {
 			Expect(dLoader1).To(Equal(dLoader2))
 		})
 
-		It("returns an error when trying to fetch a file which doesn't exist", func() {
+		It("returns an error when trying to fetch a file from a non-existent bucket", func() {
 			err := manager.Download(&DownloadRecord{Path: "non-existent-bucket/foo.pdf"}, localFile, 10*time.Second)
 			Expect(err.Error()).To(ContainSubstring("Unable to get downloader for non-existent-bucket: Region for non-existent-bucket not found"))
+		})
+
+		It("returns an error when trying to fetch a file which doesn't exist", func() {
+			err := manager.Download(&DownloadRecord{Path: "nitro-junk/non-existent-foo.pdf"}, localFile, 10*time.Second)
+			Expect(err.Error()).To(ContainSubstring("Could not fetch from S3"))
 		})
 
 		It("returns an error when getting a 0 length file", func() {


### PR DESCRIPTION
Use the new Dropbox API, which simply gives us a download URL. We send the base64-encoded URL as the last element of the Dropbox file path in a `DownloadRecord`.