### PR TITLE
Report download time only as millisecond in the log output

### DIFF
--- a/dropbox.go
+++ b/dropbox.go
@@ -41,7 +41,7 @@ func DropboxDownload(dr *DownloadRecord, localFile io.Writer, downloadTimeout ti
 		return fmt.Errorf("failed to write local file: %s", err)
 	}
 
-	log.Debugf("Took %s to download %d bytes from Dropbox for %s", time.Since(startTime), numBytes, dr.Path)
+	log.Debugf("Took %fms to download %d bytes from Dropbox for %s", time.Since(startTime).Seconds()*1000, numBytes, dr.Path)
 
 	return nil
 }

--- a/dropbox.go
+++ b/dropbox.go
@@ -41,7 +41,7 @@ func DropboxDownload(dr *DownloadRecord, localFile io.Writer, downloadTimeout ti
 		return fmt.Errorf("failed to write local file: %s", err)
 	}
 
-	log.Debugf("Took %fms to download %d bytes from Dropbox for %s", time.Since(startTime).Seconds()*1000, numBytes, dr.Path)
+	log.Debugf("Took %.2fms to download %d bytes from Dropbox for %s", time.Since(startTime).Seconds()*1000, numBytes, dr.Path)
 
 	return nil
 }

--- a/s3.go
+++ b/s3.go
@@ -133,8 +133,8 @@ func (m *S3RegionManagedDownloader) Download(dr *DownloadRecord, localFile *os.F
 	}
 
 	log.Infof(
-		"Took %s to download s3://%s/%s (%d bytes) with request ID %q and host ID %q",
-		time.Since(startTime), bucket, fname, numBytes, requestID, hostID,
+		"Took %fms to download s3://%s/%s (%d bytes) with request ID %q and host ID %q",
+		time.Since(startTime).Seconds()*1000, bucket, fname, numBytes, requestID, hostID,
 	)
 
 	if numBytes < 1 {

--- a/s3.go
+++ b/s3.go
@@ -133,7 +133,7 @@ func (m *S3RegionManagedDownloader) Download(dr *DownloadRecord, localFile *os.F
 	}
 
 	log.Infof(
-		"Took %fms to download s3://%s/%s (%d bytes) with request ID %q and host ID %q",
+		"Took %.2fms to download s3://%s/%s (%d bytes) with request ID %q and host ID %q",
 		time.Since(startTime).Seconds()*1000, bucket, fname, numBytes, requestID, hostID,
 	)
 


### PR DESCRIPTION
As time.Since() report a Duration, it could sometimes output `xyz ms` or
`xyz s` which makes it complicated to investigate the longest queries
from the log output.

According [issue-5491](https://github.com/golang/go/issues/5491), there is no time.Since().Milliseconds() implemented in Go.

Use `Duration.Seconds() * 1e3` to report milliseconds only in log messages
produced by S3 and Dropbox Download() function.